### PR TITLE
change default ajax type to GET instead of POST

### DIFF
--- a/src/Plugins/IntroMessage/IntroMessage.js
+++ b/src/Plugins/IntroMessage/IntroMessage.js
@@ -77,7 +77,7 @@ define(function( require )
 		if(pars && pars.newsUrl){
 			jQuery.ajax({
 				url: pars.newsUrl,
-				type: 'post',
+				type: 'get',
 				success: function (data) {
 					if(data){
 						jQuery('#IntroMessage .content').empty();


### PR DESCRIPTION
Change the default ajax method to GET instead of POST, since we are fetching text/html or raw text files and not posting any data.
So that you don't need to config server routes for the POST method to fetch simple file e.g. "/news.html".
Without server config, you get "POST 404 Not Found".