### PR TITLE
Fix for D-PAD Crash.

### DIFF
--- a/src/Plugins/KeyToMove/KeyToMove.js
+++ b/src/Plugins/KeyToMove/KeyToMove.js
@@ -56,7 +56,7 @@ define(function( require )
 			
 			if(Session.Playing && Session.Entity){
 				event.stopImmediatePropagation();
-				KeyEvent[event.which] = { pressed: true, continuous: event.originalEvent.repeat };
+				KeyEvent[event.which] = { pressed: true, continuous: event.originalEvent && event.originalEvent.repeat };
 				processKeysDown();
 				return false;
 			}


### PR DESCRIPTION
Updated with event.originalEvent.repeat which was required to avoid the Gamepad to crash when using D-PAD.
